### PR TITLE
Implement multi-type provider binding with TDD methodology

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ gantt
 **Install kessoku:**
 
 ```bash
-go get -tool github.com/mazrean/kessoku
+go get -tool github.com/mazrean/kessoku/cmd/kessoku
 ```
 
 **Create `main.go`:**
@@ -104,7 +104,7 @@ go generate && go run main.go
 
 **Recommended:**
 ```bash
-go get -tool github.com/mazrean/kessoku
+go get -tool github.com/mazrean/kessoku/cmd/kessoku
 ```
 
 <details>

--- a/examples/async_parallel/services.go
+++ b/examples/async_parallel/services.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	databaseConnectionDelay = 200 * time.Millisecond
-	cacheConnectionDelay    = 150 * time.Millisecond
+	databaseConnectionDelay  = 200 * time.Millisecond
+	cacheConnectionDelay     = 150 * time.Millisecond
 	messagingConnectionDelay = 180 * time.Millisecond
 )
 

--- a/examples/complex/kessoku_band.go
+++ b/examples/complex/kessoku_band.go
@@ -6,8 +6,8 @@ import "github.com/mazrean/kessoku"
 
 func InitializeComplexService(num int) *Service {
 	config := kessoku.Provide(NewConfig).Fn()()
-	interfaceValue := kessoku.Bind[Interface](kessoku.Provide(NewConcreteImpl)).Fn()()
+	concreteImpl := kessoku.Bind[Interface](kessoku.Provide(NewConcreteImpl)).Fn()()
 	str := kessoku.Value("example value").Fn()()
-	service := kessoku.Provide(NewService).Fn()(config, interfaceValue, str, num)
+	service := kessoku.Provide(NewService).Fn()(config, concreteImpl, str, num)
 	return service
 }

--- a/examples/complex/main.go
+++ b/examples/complex/main.go
@@ -36,7 +36,7 @@ type Service struct {
 	arg    int
 }
 
-func NewService(config *Config, impl Interface, value string, arg int) *Service {
+func NewService(config *Config, impl *ConcreteImpl, value string, arg int) *Service {
 	return &Service{
 		config: config,
 		impl:   impl,

--- a/examples/complex_async/services.go
+++ b/examples/complex_async/services.go
@@ -6,14 +6,14 @@ import (
 )
 
 const (
-	configCreationDelay        = 100 * time.Millisecond
-	databaseServiceDelay       = 200 * time.Millisecond
-	cacheServiceDelay          = 150 * time.Millisecond
-	messagingServiceDelay      = 180 * time.Millisecond
-	userServiceDelay           = 120 * time.Millisecond
-	sessionServiceDelay        = 100 * time.Millisecond
-	notificationServiceDelay   = 80 * time.Millisecond
-	appCreationDelay           = 50 * time.Millisecond
+	configCreationDelay      = 100 * time.Millisecond
+	databaseServiceDelay     = 200 * time.Millisecond
+	cacheServiceDelay        = 150 * time.Millisecond
+	messagingServiceDelay    = 180 * time.Millisecond
+	userServiceDelay         = 120 * time.Millisecond
+	sessionServiceDelay      = 100 * time.Millisecond
+	notificationServiceDelay = 80 * time.Millisecond
+	appCreationDelay         = 50 * time.Millisecond
 )
 
 // Config represents the application configuration.

--- a/internal/kessoku/generator.go
+++ b/internal/kessoku/generator.go
@@ -690,10 +690,14 @@ func (stmt *InjectorChainStmt) Stmt(varPool *VarPool, injector *Injector, _ func
 func (stmt *InjectorProviderCallStmt) buildLhsExpressions(varPool *VarPool) []ast.Expr {
 	var lhs []ast.Expr
 
-	// Add output parameters
+	// Add output parameters, but avoid duplicates for multi-type providers
+	seenParams := make(map[*InjectorParam]bool)
 	for _, param := range stmt.Returns {
-		paramName := param.Name(varPool)
-		lhs = append(lhs, ast.NewIdent(paramName))
+		if !seenParams[param] {
+			paramName := param.Name(varPool)
+			lhs = append(lhs, ast.NewIdent(paramName))
+			seenParams[param] = true
+		}
 	}
 
 	// Add error parameter if provider returns error

--- a/internal/kessoku/generator_test.go
+++ b/internal/kessoku/generator_test.go
@@ -145,12 +145,12 @@ func TestInjectorChainStmt_Stmt(t *testing.T) {
 					&InjectorProviderCallStmt{
 						Provider: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{configType},
+							Provides:      [][]types.Type{{configType}},
 							Requires:      []types.Type{},
 							IsReturnError: false,
 						},
 						Arguments: []*InjectorCallArgument{},
-						Returns:   []*InjectorParam{NewInjectorParam(configType)},
+						Returns:   []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 					},
 				},
 			},
@@ -163,27 +163,27 @@ func TestInjectorChainStmt_Stmt(t *testing.T) {
 					&InjectorProviderCallStmt{
 						Provider: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{configType},
+							Provides:      [][]types.Type{{configType}},
 							Requires:      []types.Type{},
 							IsReturnError: false,
 						},
 						Arguments: []*InjectorCallArgument{},
-						Returns:   []*InjectorParam{NewInjectorParam(configType)},
+						Returns:   []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 					},
 					&InjectorProviderCallStmt{
 						Provider: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{serviceType},
+							Provides:      [][]types.Type{{serviceType}},
 							Requires:      []types.Type{configType},
 							IsReturnError: false,
 						},
 						Arguments: []*InjectorCallArgument{
 							{
-								Param:  NewInjectorParam(configType),
+								Param:  NewInjectorParam([]types.Type{configType}),
 								IsWait: false,
 							},
 						},
-						Returns: []*InjectorParam{NewInjectorParam(serviceType)},
+						Returns: []*InjectorParam{NewInjectorParam([]types.Type{serviceType})},
 					},
 				},
 			},
@@ -273,17 +273,17 @@ func TestGenerateStmts(t *testing.T) {
 					&InjectorProviderCallStmt{
 						Provider: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{configType},
+							Provides:      [][]types.Type{{configType}},
 							Requires:      []types.Type{},
 							IsReturnError: false,
 							IsAsync:       false,
 						},
 						Arguments: []*InjectorCallArgument{},
-						Returns:   []*InjectorParam{NewInjectorParam(configType)},
+						Returns:   []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 					},
 				},
 				Return: &InjectorReturn{
-					Param: NewInjectorParam(configType),
+					Param: NewInjectorParam([]types.Type{configType}),
 					Return: &Return{
 						Type:        configType,
 						ASTTypeExpr: &ast.StarExpr{X: &ast.Ident{Name: "Config"}},
@@ -306,17 +306,17 @@ func TestGenerateStmts(t *testing.T) {
 					&InjectorProviderCallStmt{
 						Provider: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{serviceType},
+							Provides:      [][]types.Type{{serviceType}},
 							Requires:      []types.Type{},
 							IsReturnError: true,
 							IsAsync:       false,
 						},
 						Arguments: []*InjectorCallArgument{},
-						Returns:   []*InjectorParam{NewInjectorParam(serviceType)},
+						Returns:   []*InjectorParam{NewInjectorParam([]types.Type{serviceType})},
 					},
 				},
 				Return: &InjectorReturn{
-					Param: NewInjectorParam(serviceType),
+					Param: NewInjectorParam([]types.Type{serviceType}),
 					Return: &Return{
 						Type:        serviceType,
 						ASTTypeExpr: &ast.StarExpr{X: &ast.Ident{Name: "Service"}},
@@ -341,19 +341,19 @@ func TestGenerateStmts(t *testing.T) {
 							&InjectorProviderCallStmt{
 								Provider: &ProviderSpec{
 									Type:          ProviderTypeFunction,
-									Provides:      []types.Type{configType},
+									Provides:      [][]types.Type{{configType}},
 									Requires:      []types.Type{},
 									IsReturnError: false,
 									IsAsync:       true, // This makes it async
 								},
 								Arguments: []*InjectorCallArgument{},
-								Returns:   []*InjectorParam{NewInjectorParam(configType)},
+								Returns:   []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 							},
 						},
 					},
 				},
 				Return: &InjectorReturn{
-					Param: NewInjectorParam(configType),
+					Param: NewInjectorParam([]types.Type{configType}),
 					Return: &Return{
 						Type:        configType,
 						ASTTypeExpr: &ast.StarExpr{X: &ast.Ident{Name: "Config"}},
@@ -373,7 +373,7 @@ func TestGenerateStmts(t *testing.T) {
 				IsReturnError: true,
 				Args: []*InjectorArgument{
 					{
-						Param: NewInjectorParam(contextType),
+						Param: NewInjectorParam([]types.Type{contextType}),
 						Type:  contextType,
 						ASTTypeExpr: &ast.SelectorExpr{
 							X:   &ast.Ident{Name: "context"},
@@ -387,24 +387,24 @@ func TestGenerateStmts(t *testing.T) {
 							&InjectorProviderCallStmt{
 								Provider: &ProviderSpec{
 									Type:          ProviderTypeFunction,
-									Provides:      []types.Type{serviceType},
+									Provides:      [][]types.Type{{serviceType}},
 									Requires:      []types.Type{contextType},
 									IsReturnError: false,
 									IsAsync:       true, // This makes it async
 								},
 								Arguments: []*InjectorCallArgument{
 									{
-										Param:  NewInjectorParam(contextType),
+										Param:  NewInjectorParam([]types.Type{contextType}),
 										IsWait: false,
 									},
 								},
-								Returns: []*InjectorParam{NewInjectorParam(serviceType)},
+								Returns: []*InjectorParam{NewInjectorParam([]types.Type{serviceType})},
 							},
 						},
 					},
 				},
 				Return: &InjectorReturn{
-					Param: NewInjectorParam(serviceType),
+					Param: NewInjectorParam([]types.Type{serviceType}),
 					Return: &Return{
 						Type:        serviceType,
 						ASTTypeExpr: &ast.StarExpr{X: &ast.Ident{Name: "Service"}},
@@ -429,19 +429,19 @@ func TestGenerateStmts(t *testing.T) {
 							&InjectorProviderCallStmt{
 								Provider: &ProviderSpec{
 									Type:          ProviderTypeFunction,
-									Provides:      []types.Type{intType},
+									Provides:      [][]types.Type{{intType}},
 									Requires:      []types.Type{},
 									IsReturnError: false,
 									IsAsync:       true, // This makes it async
 								},
 								Arguments: []*InjectorCallArgument{},
-								Returns:   []*InjectorParam{NewInjectorParam(intType)},
+								Returns:   []*InjectorParam{NewInjectorParam([]types.Type{intType})},
 							},
 						},
 					},
 				},
 				Return: &InjectorReturn{
-					Param: NewInjectorParam(intType),
+					Param: NewInjectorParam([]types.Type{intType}),
 					Return: &Return{
 						Type:        intType,
 						ASTTypeExpr: &ast.Ident{Name: "int"},
@@ -464,13 +464,13 @@ func TestGenerateStmts(t *testing.T) {
 					&InjectorProviderCallStmt{
 						Provider: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{configType},
+							Provides:      [][]types.Type{{configType}},
 							Requires:      []types.Type{},
 							IsReturnError: false,
 							IsAsync:       false,
 						},
 						Arguments: []*InjectorCallArgument{},
-						Returns:   []*InjectorParam{NewInjectorParam(configType)},
+						Returns:   []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 					},
 				},
 				Return: nil, // No return
@@ -561,33 +561,33 @@ func TestGenerate(t *testing.T) {
 						&InjectorProviderCallStmt{
 							Provider: &ProviderSpec{
 								Type:          ProviderTypeFunction,
-								Provides:      []types.Type{configType},
+								Provides:      [][]types.Type{{configType}},
 								Requires:      []types.Type{},
 								IsReturnError: false,
 								ASTExpr:       configProviderExpr,
 							},
 							Arguments: []*InjectorCallArgument{},
-							Returns:   []*InjectorParam{NewInjectorParam(configType)},
+							Returns:   []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 						},
 						&InjectorProviderCallStmt{
 							Provider: &ProviderSpec{
 								Type:          ProviderTypeFunction,
-								Provides:      []types.Type{serviceType},
+								Provides:      [][]types.Type{{serviceType}},
 								Requires:      []types.Type{configType},
 								IsReturnError: false,
 								ASTExpr:       serviceProviderExpr,
 							},
 							Arguments: []*InjectorCallArgument{
 								{
-									Param:  NewInjectorParam(configType),
+									Param:  NewInjectorParam([]types.Type{configType}),
 									IsWait: false,
 								},
 							},
-							Returns: []*InjectorParam{NewInjectorParam(serviceType)},
+							Returns: []*InjectorParam{NewInjectorParam([]types.Type{serviceType})},
 						},
 					},
 					Return: &InjectorReturn{
-						Param: NewInjectorParam(serviceType),
+						Param: NewInjectorParam([]types.Type{serviceType}),
 						Return: &Return{
 							Type:        serviceType,
 							ASTTypeExpr: serviceTypeExpr,
@@ -614,7 +614,7 @@ func TestGenerate(t *testing.T) {
 					Args: []*InjectorArgument{
 						{
 							Param: func() *InjectorParam {
-								p := NewInjectorParam(intType)
+								p := NewInjectorParam([]types.Type{intType})
 								p.Ref(false) // Reference the parameter so it gets a name
 								return p
 							}(),
@@ -626,7 +626,7 @@ func TestGenerate(t *testing.T) {
 						&InjectorProviderCallStmt{
 							Provider: &ProviderSpec{
 								Type:          ProviderTypeFunction,
-								Provides:      []types.Type{serviceType},
+								Provides:      [][]types.Type{{serviceType}},
 								Requires:      []types.Type{intType},
 								IsReturnError: false,
 								ASTExpr:       serviceProviderExpr,
@@ -634,18 +634,18 @@ func TestGenerate(t *testing.T) {
 							Arguments: []*InjectorCallArgument{
 								{
 									Param: func() *InjectorParam {
-										p := NewInjectorParam(intType)
+										p := NewInjectorParam([]types.Type{intType})
 										p.Ref(false)
 										return p
 									}(),
 									IsWait: false,
 								},
 							},
-							Returns: []*InjectorParam{NewInjectorParam(serviceType)},
+							Returns: []*InjectorParam{NewInjectorParam([]types.Type{serviceType})},
 						},
 					},
 					Return: &InjectorReturn{
-						Param: NewInjectorParam(serviceType),
+						Param: NewInjectorParam([]types.Type{serviceType}),
 						Return: &Return{
 							Type:        serviceType,
 							ASTTypeExpr: serviceTypeExpr,
@@ -671,17 +671,17 @@ func TestGenerate(t *testing.T) {
 						&InjectorProviderCallStmt{
 							Provider: &ProviderSpec{
 								Type:          ProviderTypeFunction,
-								Provides:      []types.Type{serviceType},
+								Provides:      [][]types.Type{{serviceType}},
 								Requires:      []types.Type{},
 								IsReturnError: true,
 								ASTExpr:       serviceProviderExpr,
 							},
 							Arguments: []*InjectorCallArgument{},
-							Returns:   []*InjectorParam{NewInjectorParam(serviceType)},
+							Returns:   []*InjectorParam{NewInjectorParam([]types.Type{serviceType})},
 						},
 					},
 					Return: &InjectorReturn{
-						Param: NewInjectorParam(serviceType),
+						Param: NewInjectorParam([]types.Type{serviceType}),
 						Return: &Return{
 							Type:        serviceType,
 							ASTTypeExpr: serviceTypeExpr,
@@ -708,17 +708,17 @@ func TestGenerate(t *testing.T) {
 						&InjectorProviderCallStmt{
 							Provider: &ProviderSpec{
 								Type:          ProviderTypeFunction,
-								Provides:      []types.Type{serviceType},
+								Provides:      [][]types.Type{{serviceType}},
 								Requires:      []types.Type{},
 								IsReturnError: false,
 								ASTExpr:       serviceProviderExpr,
 							},
 							Arguments: []*InjectorCallArgument{},
-							Returns:   []*InjectorParam{NewInjectorParam(serviceType)},
+							Returns:   []*InjectorParam{NewInjectorParam([]types.Type{serviceType})},
 						},
 					},
 					Return: &InjectorReturn{
-						Param: NewInjectorParam(serviceType),
+						Param: NewInjectorParam([]types.Type{serviceType}),
 						Return: &Return{
 							Type:        serviceType,
 							ASTTypeExpr: serviceTypeExpr,
@@ -734,17 +734,17 @@ func TestGenerate(t *testing.T) {
 						&InjectorProviderCallStmt{
 							Provider: &ProviderSpec{
 								Type:          ProviderTypeFunction,
-								Provides:      []types.Type{serviceType},
+								Provides:      [][]types.Type{{serviceType}},
 								Requires:      []types.Type{},
 								IsReturnError: false,
 								ASTExpr:       serviceProviderExpr,
 							},
 							Arguments: []*InjectorCallArgument{},
-							Returns:   []*InjectorParam{NewInjectorParam(serviceType)},
+							Returns:   []*InjectorParam{NewInjectorParam([]types.Type{serviceType})},
 						},
 					},
 					Return: &InjectorReturn{
-						Param: NewInjectorParam(serviceType),
+						Param: NewInjectorParam([]types.Type{serviceType}),
 						Return: &Return{
 							Type:        serviceType,
 							ASTTypeExpr: serviceTypeExpr,
@@ -777,17 +777,17 @@ func TestGenerate(t *testing.T) {
 						&InjectorProviderCallStmt{
 							Provider: &ProviderSpec{
 								Type:          ProviderTypeFunction,
-								Provides:      []types.Type{serviceType},
+								Provides:      [][]types.Type{{serviceType}},
 								Requires:      []types.Type{},
 								IsReturnError: false,
 								ASTExpr:       serviceProviderExpr,
 							},
 							Arguments: []*InjectorCallArgument{},
-							Returns:   []*InjectorParam{NewInjectorParam(serviceType)},
+							Returns:   []*InjectorParam{NewInjectorParam([]types.Type{serviceType})},
 						},
 					},
 					Return: &InjectorReturn{
-						Param: NewInjectorParam(serviceType),
+						Param: NewInjectorParam([]types.Type{serviceType}),
 						Return: &Return{
 							Type:        serviceType,
 							ASTTypeExpr: serviceTypeExpr,
@@ -858,7 +858,7 @@ func TestInjectorProviderCallStmt_channelsWait(t *testing.T) {
 			stmt: &InjectorProviderCallStmt{
 				Provider: &ProviderSpec{
 					Type:     ProviderTypeFunction,
-					Provides: []types.Type{serviceType},
+					Provides: [][]types.Type{{serviceType}},
 					Requires: []types.Type{configType},
 				},
 			},
@@ -880,7 +880,7 @@ func TestInjectorProviderCallStmt_channelsWait(t *testing.T) {
 			stmt: &InjectorProviderCallStmt{
 				Provider: &ProviderSpec{
 					Type:     ProviderTypeFunction,
-					Provides: []types.Type{serviceType},
+					Provides: [][]types.Type{{serviceType}},
 					Requires: []types.Type{configType},
 				},
 			},
@@ -1085,14 +1085,14 @@ func TestGenerateVariableSpecs(t *testing.T) {
 			injector: &Injector{
 				Params: []*InjectorParam{
 					func() *InjectorParam {
-						p := NewInjectorParam(configType)
+						p := NewInjectorParam([]types.Type{configType})
 						p.Ref(false) // Reference so it gets a name
 						return p
 					}(),
 				},
 				Vars: []*InjectorParam{
 					func() *InjectorParam {
-						p := NewInjectorParam(configType)
+						p := NewInjectorParam([]types.Type{configType})
 						p.Ref(false) // Reference so it gets a name
 						return p
 					}(),
@@ -1107,14 +1107,14 @@ func TestGenerateVariableSpecs(t *testing.T) {
 			injector: &Injector{
 				Params: []*InjectorParam{
 					func() *InjectorParam {
-						p := NewInjectorParam(serviceType)
+						p := NewInjectorParam([]types.Type{serviceType})
 						p.Ref(true) // Reference with channel
 						return p
 					}(),
 				},
 				Vars: []*InjectorParam{
 					func() *InjectorParam {
-						p := NewInjectorParam(serviceType)
+						p := NewInjectorParam([]types.Type{serviceType})
 						p.Ref(true) // Reference with channel
 						return p
 					}(),
@@ -1129,29 +1129,29 @@ func TestGenerateVariableSpecs(t *testing.T) {
 			injector: &Injector{
 				Params: []*InjectorParam{
 					func() *InjectorParam {
-						p := NewInjectorParam(configType)
+						p := NewInjectorParam([]types.Type{configType})
 						p.Ref(false) // No channel
 						return p
 					}(),
 					func() *InjectorParam {
-						p := NewInjectorParam(serviceType)
+						p := NewInjectorParam([]types.Type{serviceType})
 						p.Ref(true) // With channel
 						return p
 					}(),
-					NewInjectorParam(intType), // Unreferenced (should be skipped)
+					NewInjectorParam([]types.Type{intType}), // Unreferenced (should be skipped)
 				},
 				Vars: []*InjectorParam{
 					func() *InjectorParam {
-						p := NewInjectorParam(configType)
+						p := NewInjectorParam([]types.Type{configType})
 						p.Ref(false) // No channel
 						return p
 					}(),
 					func() *InjectorParam {
-						p := NewInjectorParam(serviceType)
+						p := NewInjectorParam([]types.Type{serviceType})
 						p.Ref(true) // With channel
 						return p
 					}(),
-					NewInjectorParam(intType), // Unreferenced (should be skipped)
+					NewInjectorParam([]types.Type{intType}), // Unreferenced (should be skipped)
 				},
 			},
 			expectedSpecs:   3, // config + service + serviceChannel
@@ -1162,14 +1162,14 @@ func TestGenerateVariableSpecs(t *testing.T) {
 			name: "all unreferenced parameters",
 			injector: &Injector{
 				Params: []*InjectorParam{
-					NewInjectorParam(configType),
-					NewInjectorParam(serviceType),
-					NewInjectorParam(intType),
+					NewInjectorParam([]types.Type{configType}),
+					NewInjectorParam([]types.Type{serviceType}),
+					NewInjectorParam([]types.Type{intType}),
 				},
 				Vars: []*InjectorParam{
-					NewInjectorParam(configType),
-					NewInjectorParam(serviceType),
-					NewInjectorParam(intType),
+					NewInjectorParam([]types.Type{configType}),
+					NewInjectorParam([]types.Type{serviceType}),
+					NewInjectorParam([]types.Type{intType}),
 				},
 			},
 			expectedSpecs:   0, // All should be skipped as they have name "_"
@@ -1299,7 +1299,7 @@ func TestDetectAsyncChains(t *testing.T) {
 							&InjectorProviderCallStmt{
 								Provider: &ProviderSpec{
 									Type:     ProviderTypeFunction,
-									Provides: []types.Type{configType},
+									Provides: [][]types.Type{{configType}},
 									Requires: []types.Type{},
 									IsAsync:  false,
 								},
@@ -1307,7 +1307,7 @@ func TestDetectAsyncChains(t *testing.T) {
 							&InjectorProviderCallStmt{
 								Provider: &ProviderSpec{
 									Type:     ProviderTypeFunction,
-									Provides: []types.Type{serviceType},
+									Provides: [][]types.Type{{serviceType}},
 									Requires: []types.Type{configType},
 									IsAsync:  true, // This makes it async
 								},

--- a/internal/kessoku/graph.go
+++ b/internal/kessoku/graph.go
@@ -679,8 +679,8 @@ func (g *Graph) findAugmentingPath(u int, used []bool, matchR []int, adj [][]int
 
 func (g *Graph) topologicalSortIter() func(yield func(*node) bool) {
 	type requireCounter struct {
-		count       int
 		probidedArg []bool
+		count       int
 	}
 	waitNodes := collection.NewQueue[*node]()
 	requireCounts := make(map[*node]*requireCounter)

--- a/internal/kessoku/graph.go
+++ b/internal/kessoku/graph.go
@@ -284,19 +284,28 @@ func NewGraph(metaData *MetaData, build *BuildDirective, varPool *VarPool) (*Gra
 
 	fnProviderMap := make(map[string]*fnProvider)
 	for _, provider := range build.Providers {
-		for i, t := range provider.Provides {
-			if t == nil {
-				return nil, fmt.Errorf("provider has nil type at index %d", i)
-			}
-			key := t.String()
+		for groupIndex, typeGroup := range provider.Provides {
+			for typeIndex, t := range typeGroup {
+				if t == nil {
+					return nil, fmt.Errorf("provider has nil type at group %d, index %d", groupIndex, typeIndex)
+				}
+				key := t.String()
 
-			if _, ok := fnProviderMap[key]; ok {
-				return nil, fmt.Errorf("multiple providers provide %s", key)
-			}
+				if existing, ok := fnProviderMap[key]; ok {
+					// Allow the same provider to provide multiple types (e.g., concrete and interface)
+					// but still error if different providers try to provide the same type
+					if existing.provider != provider {
+						return nil, fmt.Errorf("multiple providers provide %s", key)
+					}
+					// If it's the same provider, just update the return index to the first occurrence
+					// This handles the case where bindProvider adds both concrete and interface types
+					continue
+				}
 
-			fnProviderMap[key] = &fnProvider{
-				provider:    provider,
-				returnIndex: i,
+				fnProviderMap[key] = &fnProvider{
+					provider:    provider,
+					returnIndex: groupIndex,
+				}
 			}
 		}
 	}
@@ -439,7 +448,7 @@ func (g *Graph) injectContextArg(injector *Injector, metaData *MetaData, varPool
 	varPool.Register("context")
 
 	// Create context parameter
-	contextParam := NewInjectorParam(contextType)
+	contextParam := NewInjectorParam([]types.Type{contextType})
 	// errgroup.WithContext(ctx) requires context.Context as the first argument
 	contextParam.Ref(false)
 
@@ -515,7 +524,7 @@ func (g *Graph) Build(metaData *MetaData, varPool *VarPool) (*Injector, error) {
 			providedNodes = initialProvidedNodes
 			poolIdx = -1 // Arguments are not in any pool
 
-			param := NewInjectorParam(n.arg.Type)
+			param := NewInjectorParam([]types.Type{n.arg.Type})
 			injector.Params = append(injector.Params, param)
 			returnValues = append(returnValues, param)
 
@@ -531,8 +540,8 @@ func (g *Graph) Build(metaData *MetaData, varPool *VarPool) (*Injector, error) {
 			providedNodes = poolProvidedNodes[poolIdx]
 
 			returnValues = make([]*InjectorParam, 0, len(n.providerSpec.Provides))
-			for _, t := range n.providerSpec.Provides {
-				param := NewInjectorParam(t)
+			for _, types := range n.providerSpec.Provides {
+				param := NewInjectorParam(types)
 				injector.Params = append(injector.Params, param)
 				injector.Vars = append(injector.Vars, param)
 				returnValues = append(returnValues, param)
@@ -669,13 +678,20 @@ func (g *Graph) findAugmentingPath(u int, used []bool, matchR []int, adj [][]int
 }
 
 func (g *Graph) topologicalSortIter() func(yield func(*node) bool) {
+	type requireCounter struct {
+		count       int
+		probidedArg []bool
+	}
 	waitNodes := collection.NewQueue[*node]()
-	requireCounts := make(map[*node]int)
+	requireCounts := make(map[*node]*requireCounter)
 	visited := make(map[*node]struct{})
 
 	for _, n := range g.nodes {
 		requireCount := len(g.reverseEdges[n])
-		requireCounts[n] = requireCount
+		requireCounts[n] = &requireCounter{
+			count:       requireCount,
+			probidedArg: make([]bool, len(n.providerArgs)),
+		}
 
 		if requireCount == 0 {
 			waitNodes.Push(n)
@@ -690,8 +706,14 @@ func (g *Graph) topologicalSortIter() func(yield func(*node) bool) {
 			visited[n] = struct{}{}
 
 			for _, edge := range g.edges[n] {
-				requireCounts[edge.node]--
-				if requireCounts[edge.node] == 0 {
+				counter := requireCounts[edge.node]
+				if counter == nil || counter.probidedArg[edge.provideArgDst] {
+					continue
+				}
+
+				counter.count--
+				counter.probidedArg[edge.provideArgDst] = true
+				if counter.count == 0 {
 					waitNodes.Push(edge.node)
 				}
 			}

--- a/internal/kessoku/graph_test.go
+++ b/internal/kessoku/graph_test.go
@@ -32,13 +32,13 @@ func TestNewGraph(t *testing.T) {
 				Providers: []*ProviderSpec{
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType},
+						Provides:      [][]types.Type{{configType}},
 						Requires:      []types.Type{},
 						IsReturnError: false,
 					},
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{serviceType},
+						Provides:      [][]types.Type{{serviceType}},
 						Requires:      []types.Type{configType},
 						IsReturnError: false,
 					},
@@ -58,13 +58,13 @@ func TestNewGraph(t *testing.T) {
 				Providers: []*ProviderSpec{
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType},
+						Provides:      [][]types.Type{{configType}},
 						Requires:      []types.Type{},
 						IsReturnError: false,
 					},
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType}, // Duplicate!
+						Provides:      [][]types.Type{{configType}}, // Duplicate!
 						Requires:      []types.Type{},
 						IsReturnError: false,
 					},
@@ -83,7 +83,7 @@ func TestNewGraph(t *testing.T) {
 				Providers: []*ProviderSpec{
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType},
+						Provides:      [][]types.Type{{configType}},
 						Requires:      []types.Type{},
 						IsReturnError: false,
 					},
@@ -103,19 +103,19 @@ func TestNewGraph(t *testing.T) {
 				Providers: []*ProviderSpec{
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{intType},
+						Provides:      [][]types.Type{{intType}},
 						Requires:      []types.Type{},
 						IsReturnError: false,
 					},
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType},
+						Provides:      [][]types.Type{{configType}},
 						Requires:      []types.Type{intType},
 						IsReturnError: false,
 					},
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{serviceType},
+						Provides:      [][]types.Type{{serviceType}},
 						Requires:      []types.Type{configType},
 						IsReturnError: false,
 					},
@@ -135,7 +135,7 @@ func TestNewGraph(t *testing.T) {
 				Providers: []*ProviderSpec{
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{serviceType},
+						Provides:      [][]types.Type{{serviceType}},
 						Requires:      []types.Type{intType}, // Missing provider for int
 						IsReturnError: false,
 					},
@@ -155,7 +155,7 @@ func TestNewGraph(t *testing.T) {
 				Providers: []*ProviderSpec{
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType, serviceType}, // Multiple returns
+						Provides:      [][]types.Type{{configType, serviceType}}, // Multiple returns
 						Requires:      []types.Type{},
 						IsReturnError: false,
 					},
@@ -175,19 +175,19 @@ func TestNewGraph(t *testing.T) {
 				Providers: []*ProviderSpec{
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType},
+						Provides:      [][]types.Type{{configType}},
 						Requires:      []types.Type{},
 						IsReturnError: false,
 					},
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{intType},
+						Provides:      [][]types.Type{{intType}},
 						Requires:      []types.Type{configType}, // Reuses config provider
 						IsReturnError: false,
 					},
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{serviceType},
+						Provides:      [][]types.Type{{serviceType}},
 						Requires:      []types.Type{configType, intType}, // Reuses both providers
 						IsReturnError: false,
 					},
@@ -254,6 +254,124 @@ func TestNewGraph(t *testing.T) {
 
 func containsError(err, substring string) bool {
 	return len(err) >= len(substring) && err[:len(substring)] == substring
+}
+
+func TestNewGraphMultiTypeProvider(t *testing.T) {
+	t.Parallel()
+
+	configType, serviceType, _ := createTestTypes()
+
+	// Create an interface type
+	interfaceType := func() types.Type {
+		obj := types.NewTypeName(0, nil, "Interface", nil)
+		return types.NewNamed(obj, types.NewInterfaceType([]*types.Func{}, nil), nil)
+	}()
+
+	tests := []struct {
+		build         *BuildDirective
+		name          string
+		expectedNodes int
+		expectError   bool
+	}{
+		{
+			name: "provider provides both concrete and interface types",
+			build: &BuildDirective{
+				InjectorName: "InitializeService",
+				Return: &Return{
+					Type: interfaceType,
+				},
+				Providers: []*ProviderSpec{
+					{
+						Type:          ProviderTypeFunction,
+						Provides:      [][]types.Type{{configType, interfaceType}}, // Both types
+						Requires:      []types.Type{},
+						IsReturnError: false,
+					},
+				},
+			},
+			expectError:   false,
+			expectedNodes: 1,
+		},
+		{
+			name: "concrete service and interface service can use same provider",
+			build: &BuildDirective{
+				InjectorName: "InitializeService",
+				Return: &Return{
+					Type: serviceType,
+				},
+				Providers: []*ProviderSpec{
+					{
+						Type:          ProviderTypeFunction,
+						Provides:      [][]types.Type{{configType, interfaceType}}, // Provides both types
+						Requires:      []types.Type{},
+						IsReturnError: false,
+					},
+					{
+						Type:          ProviderTypeFunction,
+						Provides:      [][]types.Type{{serviceType}},
+						Requires:      []types.Type{interfaceType}, // Requires the interface
+						IsReturnError: false,
+					},
+				},
+			},
+			expectError:   false,
+			expectedNodes: 2,
+		},
+		{
+			name: "should not error on duplicate types in same provider",
+			build: &BuildDirective{
+				InjectorName: "InitializeService",
+				Return: &Return{
+					Type: configType,
+				},
+				Providers: []*ProviderSpec{
+					{
+						Type:          ProviderTypeFunction,
+						Provides:      [][]types.Type{{configType, configType}}, // Duplicate should be handled
+						Requires:      []types.Type{},
+						IsReturnError: false,
+					},
+				},
+			},
+			expectError:   false,
+			expectedNodes: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			metaData := &MetaData{
+				Package: Package{
+					Name: "test",
+					Path: "test",
+				},
+				Imports: make(map[string]*ast.ImportSpec),
+			}
+
+			graph, err := NewGraph(metaData, tt.build)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if graph == nil {
+				t.Fatal("Expected graph to be non-nil")
+			}
+
+			if len(graph.nodes) != tt.expectedNodes {
+				t.Errorf("Expected %d nodes, got %d", tt.expectedNodes, len(graph.nodes))
+			}
+		})
+	}
 }
 
 func TestCreateASTTypeExpr(t *testing.T) {
@@ -653,12 +771,12 @@ func TestGraph_BuildPoolStmts(t *testing.T) {
 				{
 					providerSpec: &ProviderSpec{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType},
+						Provides:      [][]types.Type{{configType}},
 						Requires:      []types.Type{},
 						IsReturnError: false,
 					},
 					providerArgs: []*InjectorCallArgument{},
-					returnValues: []*InjectorParam{NewInjectorParam(configType)},
+					returnValues: []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 				},
 			},
 			pools:                  [][]*node{},
@@ -691,17 +809,17 @@ func TestGraph_BuildPoolStmts(t *testing.T) {
 					// provider node - should generate statement
 					providerSpec: &ProviderSpec{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType},
+						Provides:      [][]types.Type{{configType}},
 						Requires:      []types.Type{intType},
 						IsReturnError: false,
 					},
 					providerArgs: []*InjectorCallArgument{
 						{
-							Param:  NewInjectorParam(intType),
+							Param:  NewInjectorParam([]types.Type{intType}),
 							IsWait: false,
 						},
 					},
-					returnValues: []*InjectorParam{NewInjectorParam(configType)},
+					returnValues: []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 				},
 			},
 			pools:                  [][]*node{},
@@ -822,13 +940,13 @@ func TestGraph_BuildStmts(t *testing.T) {
 					{
 						providerSpec: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{configType},
+							Provides:      [][]types.Type{{configType}},
 							Requires:      []types.Type{},
 							IsReturnError: false,
 							IsAsync:       false,
 						},
 						providerArgs: []*InjectorCallArgument{},
-						returnValues: []*InjectorParam{NewInjectorParam(configType)},
+						returnValues: []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 					},
 				},
 			},
@@ -853,13 +971,13 @@ func TestGraph_BuildStmts(t *testing.T) {
 					{
 						providerSpec: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{intType},
+							Provides:      [][]types.Type{{intType}},
 							Requires:      []types.Type{},
 							IsReturnError: false,
 							IsAsync:       false,
 						},
 						providerArgs: []*InjectorCallArgument{},
-						returnValues: []*InjectorParam{NewInjectorParam(intType)},
+						returnValues: []*InjectorParam{NewInjectorParam([]types.Type{intType})},
 					},
 				},
 			},
@@ -883,26 +1001,26 @@ func TestGraph_BuildStmts(t *testing.T) {
 					{
 						providerSpec: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{configType},
+							Provides:      [][]types.Type{{configType}},
 							Requires:      []types.Type{},
 							IsReturnError: false,
 							IsAsync:       true, // Async provider
 						},
 						providerArgs: []*InjectorCallArgument{},
-						returnValues: []*InjectorParam{NewInjectorParam(configType)},
+						returnValues: []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 					},
 				},
 				{
 					{
 						providerSpec: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{serviceType},
+							Provides:      [][]types.Type{{serviceType}},
 							Requires:      []types.Type{},
 							IsReturnError: false,
 							IsAsync:       false, // Sync provider
 						},
 						providerArgs: []*InjectorCallArgument{},
-						returnValues: []*InjectorParam{NewInjectorParam(serviceType)},
+						returnValues: []*InjectorParam{NewInjectorParam([]types.Type{serviceType})},
 					},
 				},
 			},
@@ -994,14 +1112,14 @@ func TestGraph_Build_ContextInjection(t *testing.T) {
 				Providers: []*ProviderSpec{
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType},
+						Provides:      [][]types.Type{{configType}},
 						Requires:      []types.Type{},
 						IsReturnError: false,
 						IsAsync:       false,
 					},
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{serviceType},
+						Provides:      [][]types.Type{{serviceType}},
 						Requires:      []types.Type{configType},
 						IsReturnError: false,
 						IsAsync:       false,
@@ -1022,14 +1140,14 @@ func TestGraph_Build_ContextInjection(t *testing.T) {
 				Providers: []*ProviderSpec{
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType},
+						Provides:      [][]types.Type{{configType}},
 						Requires:      []types.Type{},
 						IsReturnError: false,
 						IsAsync:       true, // This should trigger context injection
 					},
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{serviceType},
+						Provides:      [][]types.Type{{serviceType}},
 						Requires:      []types.Type{configType},
 						IsReturnError: false,
 						IsAsync:       false,
@@ -1051,14 +1169,14 @@ func TestGraph_Build_ContextInjection(t *testing.T) {
 				Providers: []*ProviderSpec{
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType},
+						Provides:      [][]types.Type{{configType}},
 						Requires:      []types.Type{},
 						IsReturnError: false,
 						IsAsync:       false,
 					},
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{serviceType},
+						Provides:      [][]types.Type{{serviceType}},
 						Requires:      []types.Type{configType},
 						IsReturnError: false,
 						IsAsync:       true, // This should trigger context injection
@@ -1080,14 +1198,14 @@ func TestGraph_Build_ContextInjection(t *testing.T) {
 				Providers: []*ProviderSpec{
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{configType},
+						Provides:      [][]types.Type{{configType}},
 						Requires:      []types.Type{},
 						IsReturnError: false,
 						IsAsync:       true, // Async
 					},
 					{
 						Type:          ProviderTypeFunction,
-						Provides:      []types.Type{serviceType},
+						Provides:      [][]types.Type{{serviceType}},
 						Requires:      []types.Type{configType},
 						IsReturnError: false,
 						IsAsync:       true, // Also async

--- a/internal/kessoku/graph_test.go
+++ b/internal/kessoku/graph_test.go
@@ -349,8 +349,9 @@ func TestNewGraphMultiTypeProvider(t *testing.T) {
 				},
 				Imports: make(map[string]*ast.ImportSpec),
 			}
+			varPool := NewVarPool()
 
-			graph, err := NewGraph(metaData, tt.build)
+			graph, err := NewGraph(metaData, tt.build, varPool)
 
 			if tt.expectError {
 				if err == nil {

--- a/internal/kessoku/parser.go
+++ b/internal/kessoku/parser.go
@@ -15,6 +15,15 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
+const (
+	// bindProviderMinTypeArgs is the minimum number of type arguments required for bindProvider
+	bindProviderMinTypeArgs = 3
+	// bindProviderInternalTypeIndex is the index of the internal provider type in bindProvider type arguments
+	bindProviderInternalTypeIndex = 2
+	// asyncProviderMinTypeArgs is the minimum number of type arguments required for asyncProvider
+	asyncProviderMinTypeArgs = 2
+)
+
 // Parser analyzes Go source code to find wire build directives and providers.
 type Parser struct {
 	fset     *token.FileSet
@@ -408,12 +417,12 @@ func (p *Parser) parseProviderType(pkg *packages.Package, providerType types.Typ
 
 	switch named.Obj().Name() {
 	case "bindProvider":
-		if typeArgs.Len() < 3 {
+		if typeArgs.Len() < bindProviderMinTypeArgs {
 			break
 		}
 
 		interfaceType := typeArgs.At(0)
-		internalProviderType := typeArgs.At(2)
+		internalProviderType := typeArgs.At(bindProviderInternalTypeIndex)
 
 		intrfcType, ok := interfaceType.Underlying().(*types.Interface)
 		if !ok {
@@ -437,7 +446,7 @@ func (p *Parser) parseProviderType(pkg *packages.Package, providerType types.Typ
 
 		return requires, provides, isReturnError, isAsync, nil
 	case "asyncProvider":
-		if typeArgs.Len() < 2 {
+		if typeArgs.Len() < asyncProviderMinTypeArgs {
 			return nil, nil, false, false, fmt.Errorf("asyncProvider requires at least 2 type arguments")
 		}
 		internalProviderType := typeArgs.At(1)

--- a/internal/kessoku/parser.go
+++ b/internal/kessoku/parser.go
@@ -374,89 +374,114 @@ func (p *Parser) parseProviderArgument(pkg *packages.Package, kessokuPackageScop
 		}
 	}
 
-	methodSet := types.NewMethodSet(providerType)
-	for method := range methodSet.Methods() {
-		if method == nil {
-			slog.Debug("method is nil", "arg", arg)
-			continue
-		}
-
-		methodObj := method.Obj()
-		if methodObj == nil {
-			slog.Debug("methodObj is nil", "arg", arg)
-			continue
-		}
-
-		methodName := methodObj.Name()
-		if methodName == "Fn" {
-			fnType := methodObj.Type().(*types.Signature)
-			if fnType.Params().Len() != 0 || fnType.Results().Len() != 1 {
-				slog.Debug("fnType is not a function", "arg", arg)
-				continue
-			}
-
-			providerFnType := fnType.Results().At(0).Type()
-			if providerFnType == nil {
-				slog.Warn("get provider function type", "method", methodObj.Name(), "arg", arg)
-				continue
-			}
-
-			providerFnSig, fnSigOk := providerFnType.(*types.Signature)
-			if !fnSigOk {
-				slog.Warn("provider function is not a function", "method", methodObj.Name(), "arg", arg)
-				continue
-			}
-
-			requires := make([]types.Type, 0, providerFnSig.Params().Len())
-			for i := 0; i < providerFnSig.Params().Len(); i++ {
-				requires = append(requires, providerFnSig.Params().At(i).Type())
-			}
-
-			isReturnError := false
-			provides := make([]types.Type, 0, providerFnSig.Results().Len())
-			for i := 0; i < providerFnSig.Results().Len(); i++ {
-				if types.Identical(providerFnSig.Results().At(i).Type(), types.Universe.Lookup("error").Type()) {
-					isReturnError = true
-					continue
-				}
-
-				provides = append(provides, providerFnSig.Results().At(i).Type())
-			}
-
-			// Check if this is a bindProvider or asyncProvider
-			isAsync := false
-			if named, ok := providerType.(*types.Named); ok {
-				typeName := named.Obj().Name()
-				if typeName == "bindProvider" {
-					// For bindProvider[S, T], we want to provide type S (the interface)
-					// but keep the original requires from the wrapped provider
-					if typeArgs := named.TypeArgs(); typeArgs != nil && typeArgs.Len() >= 1 {
-						interfaceType := typeArgs.At(0)
-						provides = []types.Type{interfaceType}
-					}
-				} else if typeName == "asyncProvider" {
-					// Mark this provider as async
-					isAsync = true
-				}
-			}
-
-			build.Providers = append(build.Providers, &ProviderSpec{
-				Type:          ProviderTypeFunction,
-				Requires:      requires,
-				Provides:      provides,
-				IsReturnError: isReturnError,
-				IsAsync:       isAsync,
-				ASTExpr:       arg,
-			})
-
-			// Collect dependencies from provider expression
-			p.collectDependencies(arg, pkg.TypesInfo, imports, fileImports, varPool)
-
-			return nil
-		}
+	requires, provides, isReturnError, isAsync, err := p.parseProviderType(pkg, providerType, varPool)
+	if err != nil {
+		return fmt.Errorf("parse provider type: %w", err)
 	}
 
-	return errors.New("unsupported provider expression")
+	build.Providers = append(build.Providers, &ProviderSpec{
+		ASTExpr:       arg,
+		Type:          ProviderTypeFunction,
+		Provides:      provides,
+		Requires:      requires,
+		IsReturnError: isReturnError,
+		IsAsync:       isAsync,
+	})
+
+	// Collect dependencies from provider expression
+	p.collectDependencies(arg, pkg.TypesInfo, imports, fileImports, varPool)
+
+	return nil
+}
+
+func (p *Parser) parseProviderType(pkg *packages.Package, providerType types.Type, varPool *VarPool) ([]types.Type, [][]types.Type, bool, bool, error) {
+	named, ok := providerType.(*types.Named)
+	if !ok {
+		slog.Debug("providerType is not a named type", "providerType", providerType)
+		return nil, nil, false, false, fmt.Errorf("provider type is not a named type")
+	}
+
+	typeArgs := named.TypeArgs()
+	if typeArgs == nil {
+		return nil, nil, false, false, fmt.Errorf("provider type has no type arguments")
+	}
+
+	switch named.Obj().Name() {
+	case "bindProvider":
+		if typeArgs.Len() < 3 {
+			break
+		}
+
+		interfaceType := typeArgs.At(0)
+		internalProviderType := typeArgs.At(2)
+
+		intrfcType, ok := interfaceType.Underlying().(*types.Interface)
+		if !ok {
+			return nil, nil, false, false, fmt.Errorf("bind type argument is not an interface: %s", interfaceType)
+		}
+
+		requires, provides, isReturnError, isAsync, err := p.parseProviderType(pkg, internalProviderType, varPool)
+		if err != nil {
+			return nil, nil, false, false, fmt.Errorf("parse internal provider type: %w", err)
+		}
+
+		for i, provide := range provides {
+			for _, providedType := range provide {
+				if types.Implements(providedType, intrfcType) {
+					// If the provided type is the interface type, we can skip it
+					provides[i] = append(provides[i], interfaceType)
+					break
+				}
+			}
+		}
+
+		return requires, provides, isReturnError, isAsync, nil
+	case "asyncProvider":
+		if typeArgs.Len() < 2 {
+			return nil, nil, false, false, fmt.Errorf("asyncProvider requires at least 2 type arguments")
+		}
+		internalProviderType := typeArgs.At(1)
+
+		requires, provides, isReturnError, _, err := p.parseProviderType(pkg, internalProviderType, varPool)
+		if err != nil {
+			return nil, nil, false, false, fmt.Errorf("parse internal provider type: %w", err)
+		}
+
+		return requires, provides, isReturnError, true, nil
+	case "fnProvider":
+		if typeArgs.Len() < 1 {
+			return nil, nil, false, false, fmt.Errorf("fnProvider requires at least 1 type argument")
+		}
+
+		providerFnSig, ok := typeArgs.At(0).(*types.Signature)
+		if !ok || providerFnSig == nil {
+			slog.Debug("fnType is nil", "providerType", providerType)
+			return nil, nil, false, false, fmt.Errorf("fnProvider type argument is not a function signature")
+		}
+
+		requires := make([]types.Type, 0, providerFnSig.Params().Len())
+		for i := range providerFnSig.Params().Len() {
+			requires = append(requires, providerFnSig.Params().At(i).Type())
+		}
+
+		isReturnError := false
+		provides := make([][]types.Type, 0, providerFnSig.Results().Len())
+		for i := range providerFnSig.Results().Len() {
+			if types.Identical(providerFnSig.Results().At(i).Type(), types.Universe.Lookup("error").Type()) {
+				isReturnError = true
+				continue
+			}
+
+			provides = append(provides, []types.Type{providerFnSig.Results().At(i).Type()})
+		}
+
+		// Check if this is a bindProvider or asyncProvider
+		isAsync := false
+
+		return requires, provides, isReturnError, isAsync, nil
+	}
+
+	return nil, nil, false, false, errors.New("no valid provider function found")
 }
 
 func (p *Parser) getVarDecl(pkg *packages.Package, obj *types.Var) ast.Expr {

--- a/internal/kessoku/parser_test.go
+++ b/internal/kessoku/parser_test.go
@@ -627,13 +627,13 @@ func TestParseBindProviderMultipleTypes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		content             string
-		name                string
-		expectedBuilds      int
-		expectedProviders   int
-		expectedConcreteType string
+		content               string
+		name                  string
+		expectedConcreteType  string
 		expectedInterfaceType string
-		shouldError         bool
+		expectedBuilds        int
+		expectedProviders     int
+		shouldError           bool
 	}{
 		{
 			name: "bind provider should provide both concrete and interface types",
@@ -752,7 +752,7 @@ var _ = kessoku.Inject[*ConcreteService](
 				// provides the interface type, not both types. After implementing the feature,
 				// this test should verify that bindProvider.Provides contains both types.
 				t.Logf("Current bind provider provides: %v", bindProvider.Provides)
-				
+
 				// This is what we want to achieve: bindProvider should provide both types
 				// Count total types across all groups
 				totalTypes := 0
@@ -969,13 +969,13 @@ func TestParseBindProviderInterfaces(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		content                      string
-		name                         string
-		expectedBuilds               int
-		expectedProviders            int
-		expectedConcreteTypeProvided bool
+		content                       string
+		name                          string
+		expectedBuilds                int
+		expectedProviders             int
+		expectedConcreteTypeProvided  bool
 		expectedInterfaceTypeProvided bool
-		shouldError                  bool
+		shouldError                   bool
 	}{
 		{
 			name: "bind provider should provide both concrete and interface types for dependency resolution",
@@ -1035,8 +1035,8 @@ var _ = kessoku.Inject[*App](
 `,
 			expectedBuilds:                1,
 			expectedProviders:             4,
-			expectedConcreteTypeProvided:  true,  // This is what we want to achieve
-			expectedInterfaceTypeProvided: true,  // This is what we want to achieve
+			expectedConcreteTypeProvided:  true, // This is what we want to achieve
+			expectedInterfaceTypeProvided: true, // This is what we want to achieve
 			shouldError:                   false,
 		},
 	}

--- a/internal/kessoku/parser_test.go
+++ b/internal/kessoku/parser_test.go
@@ -691,13 +691,14 @@ var _ = kessoku.Inject[*ConcreteService](
 
 			tempDir := t.TempDir()
 			testFile := filepath.Join(tempDir, "test.go")
+			varPool := NewVarPool()
 
 			if err := os.WriteFile(testFile, []byte(tt.content), 0644); err != nil {
 				t.Fatalf("Failed to write test file: %v", err)
 			}
 
 			parser := NewParser()
-			metadata, builds, err := parser.ParseFile(testFile)
+			metadata, builds, err := parser.ParseFile(testFile, varPool)
 
 			if tt.shouldError {
 				if err == nil {
@@ -1047,13 +1048,14 @@ var _ = kessoku.Inject[*App](
 
 			tempDir := t.TempDir()
 			testFile := filepath.Join(tempDir, "test.go")
+			varPool := NewVarPool()
 
 			if err := os.WriteFile(testFile, []byte(tt.content), 0644); err != nil {
 				t.Fatalf("Failed to write test file: %v", err)
 			}
 
 			parser := NewParser()
-			metadata, builds, err := parser.ParseFile(testFile)
+			metadata, builds, err := parser.ParseFile(testFile, varPool)
 
 			if tt.shouldError {
 				if err == nil {

--- a/internal/kessoku/provider.go
+++ b/internal/kessoku/provider.go
@@ -47,9 +47,9 @@ type BuildDirective struct {
 }
 
 type InjectorParam struct {
-	types       []types.Type
 	name        string
 	channelName string
+	types       []types.Type
 	refCounter  int
 	withChannel bool
 }

--- a/internal/kessoku/provider.go
+++ b/internal/kessoku/provider.go
@@ -28,7 +28,7 @@ const (
 type ProviderSpec struct {
 	ASTExpr       ast.Expr
 	Type          ProviderType
-	Provides      []types.Type
+	Provides      [][]types.Type
 	Requires      []types.Type
 	IsReturnError bool
 	IsAsync       bool
@@ -47,16 +47,16 @@ type BuildDirective struct {
 }
 
 type InjectorParam struct {
-	t           types.Type
+	types       []types.Type
 	name        string
 	channelName string
 	refCounter  int
 	withChannel bool
 }
 
-func NewInjectorParam(t types.Type) *InjectorParam {
+func NewInjectorParam(ts []types.Type) *InjectorParam {
 	return &InjectorParam{
-		t: t,
+		types: ts,
 	}
 }
 
@@ -73,8 +73,7 @@ func (p *InjectorParam) Name(varPool *VarPool) string {
 	if p.refCounter == 0 {
 		return "_"
 	}
-
-	p.name = varPool.Get(p.t)
+	p.name = varPool.Get(p.types[0])
 
 	return p.name
 }
@@ -87,7 +86,7 @@ func (p *InjectorParam) ChannelName(varPool *VarPool) string {
 	if p.refCounter == 0 {
 		return "_"
 	}
-	p.channelName = varPool.GetChannel(p.t)
+	p.channelName = varPool.GetChannel(p.types[0])
 
 	return p.channelName
 }
@@ -97,7 +96,7 @@ func (p *InjectorParam) WithChannel() bool {
 }
 
 func (p *InjectorParam) Type() types.Type {
-	return p.t
+	return p.types[0]
 }
 
 type InjectorArgument struct {

--- a/internal/kessoku/provider_test.go
+++ b/internal/kessoku/provider_test.go
@@ -40,7 +40,7 @@ func TestInjectorParam(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			param := NewInjectorParam(tt.paramType)
+			param := NewInjectorParam([]types.Type{tt.paramType})
 
 			// Add references
 			for i := 0; i < tt.refCount; i++ {
@@ -69,7 +69,7 @@ func TestInjectorParamChannelName(t *testing.T) {
 		{
 			name: "unreferenced parameter",
 			setupParam: func() *InjectorParam {
-				return NewInjectorParam(intType) // No Ref() call
+				return NewInjectorParam([]types.Type{intType}) // No Ref() call
 			},
 			expectedResult:     "_",
 			shouldBeUnderscore: true,
@@ -77,7 +77,7 @@ func TestInjectorParamChannelName(t *testing.T) {
 		{
 			name: "referenced parameter with channel",
 			setupParam: func() *InjectorParam {
-				p := NewInjectorParam(serviceType)
+				p := NewInjectorParam([]types.Type{serviceType})
 				p.Ref(true) // Reference with channel
 				return p
 			},
@@ -87,7 +87,7 @@ func TestInjectorParamChannelName(t *testing.T) {
 		{
 			name: "referenced parameter without channel",
 			setupParam: func() *InjectorParam {
-				p := NewInjectorParam(serviceType)
+				p := NewInjectorParam([]types.Type{serviceType})
 				p.Ref(false) // Reference without channel
 				return p
 			},
@@ -123,7 +123,7 @@ func TestInjectorParamChannelName(t *testing.T) {
 	t.Run("caching behavior", func(t *testing.T) {
 		t.Parallel()
 
-		param := NewInjectorParam(serviceType)
+		param := NewInjectorParam([]types.Type{serviceType})
 		param.Ref(true) // Reference with channel
 		varPool := NewVarPool()
 
@@ -166,13 +166,13 @@ func TestInjectorChainStmt_HasAsync(t *testing.T) {
 					&InjectorProviderCallStmt{
 						Provider: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{configType},
+							Provides:      [][]types.Type{{configType}},
 							Requires:      []types.Type{},
 							IsReturnError: false,
 							IsAsync:       false,
 						},
 						Arguments: []*InjectorCallArgument{},
-						Returns:   []*InjectorParam{NewInjectorParam(configType)},
+						Returns:   []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 					},
 				},
 			},
@@ -185,13 +185,13 @@ func TestInjectorChainStmt_HasAsync(t *testing.T) {
 					&InjectorProviderCallStmt{
 						Provider: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{configType},
+							Provides:      [][]types.Type{{configType}},
 							Requires:      []types.Type{},
 							IsReturnError: false,
 							IsAsync:       true,
 						},
 						Arguments: []*InjectorCallArgument{},
-						Returns:   []*InjectorParam{NewInjectorParam(configType)},
+						Returns:   []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 					},
 				},
 			},
@@ -204,29 +204,29 @@ func TestInjectorChainStmt_HasAsync(t *testing.T) {
 					&InjectorProviderCallStmt{
 						Provider: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{configType},
+							Provides:      [][]types.Type{{configType}},
 							Requires:      []types.Type{},
 							IsReturnError: false,
 							IsAsync:       false, // sync
 						},
 						Arguments: []*InjectorCallArgument{},
-						Returns:   []*InjectorParam{NewInjectorParam(configType)},
+						Returns:   []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 					},
 					&InjectorProviderCallStmt{
 						Provider: &ProviderSpec{
 							Type:          ProviderTypeFunction,
-							Provides:      []types.Type{serviceType},
+							Provides:      [][]types.Type{{serviceType}},
 							Requires:      []types.Type{configType},
 							IsReturnError: false,
 							IsAsync:       true, // async
 						},
 						Arguments: []*InjectorCallArgument{
 							{
-								Param:  NewInjectorParam(configType),
+								Param:  NewInjectorParam([]types.Type{configType}),
 								IsWait: false,
 							},
 						},
-						Returns: []*InjectorParam{NewInjectorParam(serviceType)},
+						Returns: []*InjectorParam{NewInjectorParam([]types.Type{serviceType})},
 					},
 				},
 			},
@@ -241,13 +241,13 @@ func TestInjectorChainStmt_HasAsync(t *testing.T) {
 							&InjectorProviderCallStmt{
 								Provider: &ProviderSpec{
 									Type:          ProviderTypeFunction,
-									Provides:      []types.Type{configType},
+									Provides:      [][]types.Type{{configType}},
 									Requires:      []types.Type{},
 									IsReturnError: false,
 									IsAsync:       true, // nested async
 								},
 								Arguments: []*InjectorCallArgument{},
-								Returns:   []*InjectorParam{NewInjectorParam(configType)},
+								Returns:   []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 							},
 						},
 					},
@@ -264,13 +264,13 @@ func TestInjectorChainStmt_HasAsync(t *testing.T) {
 							&InjectorProviderCallStmt{
 								Provider: &ProviderSpec{
 									Type:          ProviderTypeFunction,
-									Provides:      []types.Type{configType},
+									Provides:      [][]types.Type{{configType}},
 									Requires:      []types.Type{},
 									IsReturnError: false,
 									IsAsync:       false, // nested sync
 								},
 								Arguments: []*InjectorCallArgument{},
-								Returns:   []*InjectorParam{NewInjectorParam(configType)},
+								Returns:   []*InjectorParam{NewInjectorParam([]types.Type{configType})},
 							},
 						},
 					},
@@ -317,7 +317,7 @@ func TestInjectorParam_Type(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			param := NewInjectorParam(tt.typeExpr)
+			param := NewInjectorParam([]types.Type{tt.typeExpr})
 			result := param.Type()
 			if result != tt.typeExpr {
 				t.Errorf("Type() = %v, want %v", result, tt.typeExpr)


### PR DESCRIPTION
## Summary

This PR implements multi-type provider binding functionality using Test-Driven Development (TDD) methodology. The implementation allows providers to bind to multiple types simultaneously, which is particularly useful for interface implementations where both concrete and interface types need to be available for dependency injection.

### Key Features

• **Multi-type Provider Support**: Providers can now bind to multiple types through `[][]types.Type` structure
• **Enhanced Bind Interface**: `kessoku.Bind[Interface]` now provides both concrete and interface types  
• **Comprehensive Test Coverage**: Full TDD implementation with extensive test coverage
• **Backward Compatibility**: All existing functionality remains intact

### Changes Made

1. **Core Data Structure Changes** (`provider.go`):
   - Refactored `ProviderSpec.Provides` from `[]types.Type` to `[][]types.Type`
   - Updated `InjectorParam` to support multiple types with `[]types.Type`
   - Modified constructor and methods to work with new structure

2. **Parser Enhancements** (`parser.go`):
   - Added `parseProviderType` method to handle `bindProvider`, `asyncProvider`, and `fnProvider`
   - Enhanced `bindProvider` to provide both concrete and interface types
   - Improved interface type checking and validation

3. **Graph Building Updates** (`graph.go`):
   - Modified dependency graph to handle nested type groups
   - Enhanced provider resolution to support multi-type bindings
   - Fixed topological sorting for multi-type provider arguments

4. **Code Generation Support** (`generator.go`):
   - Updated code generation to work with `[][]types.Type` structure
   - Ensured proper handling of multi-type providers in generated code

5. **Comprehensive Test Suite**:
   - Added TDD tests for multi-type provider binding
   - Created tests for `bindProvider` interface implementation
   - Updated all existing tests to work with new structure
   - All tests pass with 100% backward compatibility

### Example Usage

```go
// Provider that binds to both concrete and interface types
var _ = kessoku.Inject[*Service](
    "InitializeService",
    kessoku.Bind[Interface](kessoku.Provide(NewConcreteImpl)),
    kessoku.Provide(NewService),
)

// Can now inject both concrete and interface types
type ServiceNeedsInterface struct {
    impl Interface  // Uses interface type
}

type ServiceNeedsConcrete struct {
    impl *ConcreteImpl  // Uses concrete type
}
```

### Testing

- All existing tests continue to pass
- New comprehensive test suite covers multi-type binding scenarios
- TDD methodology ensures robust implementation
- Lint and build checks pass

### Breaking Changes

None. This is a backward-compatible enhancement that extends existing functionality without breaking changes.

🤖 Generated with [Claude Code](https://claude.ai/code)