### PR TITLE
Handle case when no sync pool exists in dependency graph building

### DIFF
--- a/internal/kessoku/graph.go
+++ b/internal/kessoku/graph.go
@@ -870,6 +870,15 @@ func (g *Graph) buildStmts(pools [][]*node, nodeProvidedNodes map[*node]map[*nod
 			return nil, fmt.Errorf("build sync pool statements: %w", err)
 		}
 		stmts = append(stmts, parentStmts...)
+	} else {
+		// If no sync pool, just start with the first available async pool
+		parentPoolIdx := initialPoolIdxs[0]
+		visited[parentPoolIdx] = true
+		parentStmts, err := g.buildPoolStmts(pools[parentPoolIdx], pools, visited, poolDependencyMap, nodeProvidedNodes)
+		if err != nil {
+			return nil, fmt.Errorf("build first async pool statements: %w", err)
+		}
+		stmts = append(stmts, parentStmts...)
 	}
 
 	// Then add all remaining ready async pools as chain statements


### PR DESCRIPTION
## Summary
- Add else branch to handle scenarios where no sync pool is present in the dependency injection graph
- Start with the first available async pool when sync pool doesn't exist
- Ensures proper initialization of dependency injection execution flow for async-only scenarios

## Test plan
- [ ] Run existing tests to ensure no regressions: `go test -v ./...`
- [ ] Test dependency injection with async-only pool configurations
- [ ] Verify generated code works correctly when no sync dependencies exist

🤖 Generated with [Claude Code](https://claude.ai/code)