### PR TITLE
uber/fx -> uber-go/dig

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ sudo apk add --allow-untrusted kessoku_amd64.apk
 
 ## vs Alternatives
 
-| | Kessoku | google/wire | uber/fx |
+| | Kessoku | google/wire | uber-go/dig |
 |---|---------|-------------|---------|
 | **Startup Speed** | Parallel | Sequential | Sequential + runtime |
 | **Learning Curve** | Minimal | Minimal | Steep |


### PR DESCRIPTION
This pull request updates the alternatives comparison table in the `README.md` to clarify the naming of a dependency injection library. The most important change is a correction to the name of the Uber Go library in the table.

Documentation update:

* Changed the library name from `uber/fx` to the correct `uber-go/dig` in the alternatives comparison table in `README.md`.