### PR TITLE
ci: keep go.work in sync when dependency updates raise a go directive

### DIFF
--- a/.github/renovate-global.json
+++ b/.github/renovate-global.json
@@ -1,0 +1,5 @@
+{
+  "platform": "github",
+  "onboarding": false,
+  "allowedCommands": ["^go work use$"]
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,65 @@
+name: Renovate
+
+on:
+  schedule:
+    # Every three hours; the "*" character has special semantics in YAML, so quote it.
+    - cron: '0 */3 * * *'
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: Renovate log level
+        type: choice
+        options: [info, debug]
+        default: info
+      dryRun:
+        description: Dry run (no branches, PRs or commits are written)
+        type: boolean
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/renovate.yml
+      - .github/renovate-global.json
+      - renovate.json
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    environment: Renovate
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Resolve app bot user ID
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          echo "id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v46.3.0
+        with:
+          configurationFile: .github/renovate-global.json
+          token: ${{ steps.app-token.outputs.token }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_USERNAME: ${{ steps.app-token.outputs.app-slug }}[bot]
+          RENOVATE_GIT_AUTHOR: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.app-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun && 'full' || '' }}
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/.mise.toml
+++ b/.mise.toml
@@ -14,40 +14,54 @@ goreleaser = "2.17.1"
 uv = "0.12.3"
 "pipx:skills-ref[uvx=true]" = "0.1.1"
 
+[tasks."work:sync"]
+description = "Sync go.work's go directive with the workspace modules (run before any go invocation)"
+hide = true
+run = "go work use"
+
 [tasks.fmt]
 description = "Format all Go source"
+depends = ["work:sync"]
 run = "go fmt ./..."
 
 [tasks.build]
 description = "Build the kessoku CLI binary"
+depends = ["work:sync"]
 run = "go build -o bin/kessoku ./cmd/kessoku"
 
 [tasks.generate]
 description = "Run go:generate across the workspace"
+depends = ["work:sync"]
 run = "go generate ./..."
 
 [tasks.test]
 description = "Run the full test suite"
+depends = ["work:sync"]
 run = "go test -v ./..."
 
 [tasks."test:ci"]
 description = "Run tests with race detector + coverage (matches CI)"
+depends = ["work:sync"]
 run = "go test -v -race -coverprofile=coverage.out ./internal/..."
 
 [tasks."test:golden-update"]
 description = "Regenerate golden codegen fixtures"
+depends = ["work:sync"]
 run = "go test -v -run TestGoldenGeneration ./internal/kessoku/... -update"
 
 [tasks.lint]
 description = "Run the custom lint module (govet + staticcheck + stylecheck)"
+depends = ["work:sync"]
 run = "go tool lint ./..."
 
 [tasks."lint:fix"]
 description = "Run the custom lint module with autofix"
+depends = ["work:sync"]
 run = "go tool lint -fix ./..."
 
 [tasks.apicompat]
 description = "Check public API compatibility against the latest release"
+depends = ["work:sync"]
 run = "go tool apicompat github.com/mazrean/kessoku@latest github.com/mazrean/kessoku"
 
 [tasks."validate-skills"]
@@ -56,14 +70,17 @@ run = "agentskills validate internal/llmsetup/skills/kessoku-di"
 
 [tasks."release:build"]
 description = "Build release binaries with GoReleaser (no publish)"
+depends = ["work:sync"]
 run = "goreleaser build --clean --skip=validate"
 
 [tasks."release:snapshot"]
 description = "Build a full snapshot release with GoReleaser (no publish)"
+depends = ["work:sync"]
 run = "goreleaser release --snapshot --clean"
 
 [tasks."release:publish"]
 description = "Publish a release with GoReleaser"
+depends = ["work:sync"]
 run = "goreleaser release --clean --skip=validate"
 
 [tasks.check]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,14 @@ Build, test, lint, and release operations are consolidated as `mise` tasks in
 `.mise.toml` (run `mise tasks` to list them); CI calls these same tasks so local
 runs match CI exactly.
 
+Every go-invoking task depends on the hidden `work:sync` task (`go work use`),
+which realigns the `go` directive in `go.work` with the workspace modules.
+Dependency-update PRs raise a module's `go` directive without touching `go.work`
+(e.g. a `honnef.co/go/tools` bump moves `tools/go.mod` to `go 1.26.0` on its
+own), which otherwise breaks every go command with `module tools listed in
+go.work file requires go >= X, but go.work lists go Y`. `work:sync` fixes that
+before the command runs; commit the resulting `go.work` change with the update.
+
 ```bash
 # Build
 mise run build                             # go build -o bin/kessoku ./cmd/kessoku

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Dependency-update PRs raise a module's `go` directive without touching `go.work`
 own), which otherwise breaks every go command with `module tools listed in
 go.work file requires go >= X, but go.work lists go Y`. `work:sync` fixes that
 before the command runs; commit the resulting `go.work` change with the update.
+Renovate handles its own PRs via `postUpgradeTasks` (see Tooling), so `work:sync` is
+the safety net for everything else.
 
 ```bash
 # Build
@@ -159,3 +161,11 @@ Migration tool location: `internal/migrate/`.
 - Code intelligence: `serena` (multi-language LSP) + `gopls` (Go LSP) MCPs declared in `apm.yml`.
 - Spec-driven development uses `mazrean/agent-skills/skills/writing-*`. `cc-sdd` /
   `github/spec-kit` are deprecated org-wide and removed from `mise.toml`.
+- Dependency updates run through **self-hosted Renovate**: `.github/workflows/renovate.yml`
+  (GitHub App token from the `Renovate` environment) plus the global config
+  `.github/renovate-global.json`, which allowlists the single post-upgrade command
+  `go work use`. `renovate.json` attaches that command to every `gomod` update, so a
+  bump that raises a module's `go` directive carries the matching `go.work` change in
+  the same commit. The Mend-hosted Renovate App must stay uninstalled for this repo —
+  running both bots would double every PR. `gitIgnoredAuthors` lets the self-hosted
+  bot adopt the branches the Mend app left behind; drop it once those PRs are gone.

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,29 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "gitIgnoredAuthors": [
+    "29139614+renovate[bot]@users.noreply.github.com"
+  ],
+  "packageRules": [
+    {
+      "description": "A dependency bump can raise a module's go directive on its own, which leaves go.work behind and breaks every go command in the workspace. Realign it inside the same commit.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "go work use"
+        ],
+        "fileFilters": [
+          "go.work",
+          "go.work.sum"
+        ],
+        "executionMode": "update",
+        "installTools": {
+          "golang": {}
+        }
+      }
+    }
   ]
 }


### PR DESCRIPTION
## Summary

依存更新が module の `go` directive を上げると `go.work` が取り残され、workspace 内のあらゆる go コマンドが落ちる:

```
go: module tools listed in go.work file requires go >= 1.26.0, but go.work lists go 1.25.0; to update it:
	go work use
```

現に #198 (honnef.co/go/tools v0.8.1) は `tools/go.mod` の `go 1.25.0 → 1.26.0` だけを含み、build / test / lint / api-compatibility の 4 job が落ちている。これを二段で自動化する。

### 1. ローカル・CI: `work:sync` mise task

`go work use` を走らせる hidden task を追加し、go を叩く全タスク (`fmt` `build` `generate` `test` `test:ci` `test:golden-update` `lint` `lint:fix` `apicompat` `release:*`) の `depends` に入れた。mise が依存を dedupe するので `mise run check` でも 1 回だけ (~7ms)。CI は同じ task を呼ぶので、そのまま治る。

### 2. Renovate PR: self-hosted Renovate + `postUpgradeTasks`

Mend hosted app では解決できない (`allowedCommands` は self-hosted 専用、`go.work` 用の `postUpdateOptions` も存在しない) ため、GitHub App で self-host に移行する。

- `.github/workflows/renovate.yml` — 3h ごと + `workflow_dispatch` (`logLevel` / `dryRun`)。`Renovate` environment の `APP_ID` / `APP_PRIVATE_KEY` から token を発行
- `.github/renovate-global.json` — global config。`allowedCommands` は `^go work use$` のみ
- `renovate.json` — `matchManagers: ["gomod"]` に `postUpgradeTasks` を紐付け。`installTools.golang` でコンテナに toolchain を入れ、`fileFilters` で `go.work` / `go.work.sum` だけを既存の commit に足す

## 検証

- HEAD の worktree で `GOWORK=off go get honnef.co/go/tools@v0.8.0-rc.1` → エラーを完全再現。その状態で `mise run build` すると `work:sync` が先に走って go.work が 1.26.0 になりビルド成功
- 複数タスク同時実行でも `work:sync` は 1 回だけ (7.3ms)。冪等
- `go work use` は go.work の go 行だけを書き換える。`GOTOOLCHAIN` 既定値 (`auto`) なら古い toolchain でも `switching to go1.26.8` で自走 (`local` だと失敗するが、containerbase は固定していないし `installTools` は latest golang を入れる)
- `go.work` の go directive は module の `-lang` を上書きしない (go.work 1.26 / go.mod 1.21 で range-over-func が `-lang go1.21` として弾かれることを確認)
- `renovate-config-validator` で `renovate.json` / `.github/renovate-global.json` とも通過
- Renovate の executor 実装を確認: `executionMode: "update"` は upgrade ごとの config を見るので packageRules スコープが確実に効く。`fileFilters` は既存の `updatedArtifacts` を引き継いだ上で追加するため、依存更新の差分が落ちることはない

## マージ前に必要な設定

1. GitHub App の権限: Contents RW / Pull requests RW / Issues RW / **Workflows RW** / Metadata R、`mazrean/kessoku` に install
2. **Mend-hosted Renovate App をこのリポジトリから外す** — 残すと PR が二重になり、Mend 側は `go work use` が allowlist に無いと PR 本文に警告を出す
3. 初回は `workflow_dispatch` を `logLevel=debug` で手動実行。成功の合図は #198 に App 名義の rebase commit が乗り `go.work` が `-go 1.25.0 / +go 1.26.0` になること

既存の Renovate PR (#191 #195 #196 #198) は閉じないこと。Renovate は閉じた PR を「拒否された更新」として再作成しない。代わりに `gitIgnoredAuthors` で Mend bot 名義の branch を self-hosted bot が引き継ぐようにしてある。4 本が片付いたら `gitIgnoredAuthors` は削除可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUYy1CsUT51oW6JeF3XrxJ